### PR TITLE
Replace psycopg2 requirement with psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ wordcloud== 1.9.3
 matplotlib==3.8.2
 seaborn== 0.13.2
 spacy==3.7.4
-psycopg2==2.9.9
+psycopg2-binary==2.9.9
 gunicorn==21.2.0
 
 


### PR DESCRIPTION
Its better because we don't have to build it ourselves.